### PR TITLE
removed engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "git://github.com/danielzzz/node-portchecker.git"
   },
-  "engines": {
-    "node": "~0.8.5"
-  },
   "dependencies": {},
   "devDependencies": {},
   "main":"index.js"


### PR DESCRIPTION
Removed the `engines` config from the package.json. This is blocked by the `yarn` installer now.